### PR TITLE
Refresh token flow bug-fix

### DIFF
--- a/TSheetsApi/UserAuthentication.cs
+++ b/TSheetsApi/UserAuthentication.cs
@@ -127,7 +127,7 @@ namespace TSheets
                 _token = null;
                 try
                 {
-                    _token = RestClient.RefreshToken(refreshToken.refresh_token, _connectionInfo);
+                    _token = RestClient.RefreshToken(refreshToken, _connectionInfo);
                 }
                 catch (ApiException ex)
                 {

--- a/TSheetsApi/UserAuthentication.cs
+++ b/TSheetsApi/UserAuthentication.cs
@@ -123,10 +123,11 @@ namespace TSheets
             }
             else if (_token.NeedsRefresh())
             {
+                var refreshToken = _token.refresh_token;
                 _token = null;
                 try
                 {
-                    _token = RestClient.RefreshToken(_token.refresh_token, _connectionInfo);
+                    _token = RestClient.RefreshToken(refreshToken.refresh_token, _connectionInfo);
                 }
                 catch (ApiException ex)
                 {


### PR DESCRIPTION
Fix issue that resulted in an exception being thrown everytime the refresh flow was triggered. _token was set to null, then immediately had its 'refresh_token' property accessed, which always resulted in an exception.